### PR TITLE
Improve multi-target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,12 @@ build-esp32c3 = "build --release --target riscv32imc-unknown-none-elf --features
 build-esp32c6 = "build --release --target riscv32imac-unknown-none-elf --features esp32c6"
 build-esp32s2 = "build --release --target xtensa-esp32s2-none-elf --features esp32s2"
 build-esp32s3 = "build --release --target xtensa-esp32s3-none-elf --features esp32s3"
+run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
+run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"
+run-esp32c3 = "run --release --target riscv32imc-unknown-none-elf --features esp32c3"
+run-esp32c6 = "run --release --target riscv32imac-unknown-none-elf --features esp32c6"
+run-esp32s2 = "run --release --target xtensa-esp32s2-none-elf --features esp32s2"
+run-esp32s3 = "run --release --target xtensa-esp32s3-none-elf --features esp32s3"
 
 [target.xtensa-esp32-none-elf]
 runner = "espflash flash --baud=921600 --monitor --chip esp32"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,8 @@ jobs:
       - name: Build project
         run: cargo +${{ matrix.device.toolchain }} build-${{ matrix.device.soc }} --release
 
+      - name: Check lints and format
+        if: ${{ !contains(fromJson('["esp32c6"]'), matrix.device.soc) }}
+        run: |
+          cargo +${{ matrix.device.toolchain }} clippy --features ${matrix.device.soc} --target riscv32imac-unknown-none-elf -- -D warnings
+          cargo +${{ matrix.device.toolchain }} fmt -- --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Rust toolchain for RISC-V
         if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
           toolchain: 1.86.0
@@ -46,7 +46,7 @@ jobs:
           version: 1.86.0.0
 
       - name: Build project
-        run: cargo +${{ matrix.device.toolchain }} build-${{ matrix.device.soc }} --release
+        run: cargo +${{ matrix.device.toolchain }} build-${{ matrix.device.soc }}
 
       - name: Check lints and format
         if: ${{ !contains(fromJson('["esp32c6"]'), matrix.device.soc) }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         run: cargo +${{ matrix.device.toolchain }} build-${{ matrix.device.soc }}
 
       - name: Check lints and format
-        if: ${{ !contains(fromJson('["esp32c6"]'), matrix.device.soc) }}
+        if: ${{ contains(fromJson('["esp32c6"]'), matrix.device.soc) }}
         run: |
-          cargo +${{ matrix.device.toolchain }} clippy --features ${matrix.device.soc} --target riscv32imac-unknown-none-elf -- -D warnings
+          cargo +${{ matrix.device.toolchain }} clippy --features ${{ matrix.device.soc }} --target riscv32imac-unknown-none-elf -- -D warnings
           cargo +${{ matrix.device.toolchain }} fmt -- --check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,19 +10,40 @@ on:
 
 jobs:
   build:
+    name: Build ${{ matrix.device.soc }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        device: [
+            # RISC-V devices:
+            { soc: "esp32c2", toolchain: "stable" },
+            { soc: "esp32c3", toolchain: "stable" },
+            { soc: "esp32c6", toolchain: "stable" },
+            # Xtensa devices:
+            { soc: "esp32", toolchain: "esp" },
+            { soc: "esp32s2", toolchain: "esp" },
+            { soc: "esp32s3", toolchain: "esp" },
+        ]
     steps:
       - name: Cache
         uses: mozilla-actions/sccache-action@v0.0.7
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup Rust toolchain
+      - name: Setup Rust toolchain for RISC-V
+        if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
         uses: dtolnay/rust-toolchain@stable
         with:
+          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
           toolchain: 1.86.0
-      - name: Install RISCV toolchain (ESP32-C6)
-        run: |
-          rustup toolchain install stable --component rust-src
-          rustup target add riscv32imac-unknown-none-elf
+          components: rust-src
+      - name: Setup Rust toolchain for Xtensa
+        if: ${{ contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          ldproxy: false
+          version: 1.86.0.0
+
       - name: Build project
-        run: cargo build --release
+        run: cargo +${{ matrix.device.toolchain }} build-${{ matrix.device.soc }} --release
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          toolchain: 1.86.0
+          toolchain: stable
           components: rust-src
       - name: Setup Rust toolchain for Xtensa
         if: ${{ contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}

--- a/src/espressif/buffered_uart.rs
+++ b/src/espressif/buffered_uart.rs
@@ -1,12 +1,12 @@
+use embassy_futures::select::select;
 /// Wrapper around bidirectional embassy-sync Pipes, in order to handle UART
 /// RX/RX happening in an InterruptExecutor at higher priority.
 ///
 /// Doesn't implement the InterruptExecutor, in the task in the app should await
 /// the 'run' async function.
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, pipe::Pipe};
-use embassy_futures::select::select;
-use esp_hal::Async;
 use esp_hal::uart::Uart;
+use esp_hal::Async;
 
 // Sizes of the software buffers. Inward is more
 // important as an overrun here drops bytes. A full outward
@@ -23,13 +23,14 @@ pub struct BufferedUart {
     inward: Pipe<CriticalSectionRawMutex, INWARD_BUF_SZ>,
 }
 
-pub struct Config {
-
-}
+pub struct Config {}
 
 impl BufferedUart {
     pub fn new() -> Self {
-        BufferedUart { outward: Pipe::new(), inward: Pipe::new() }
+        BufferedUart {
+            outward: Pipe::new(),
+            inward: Pipe::new(),
+        }
     }
 
     /// Transfer data between the UART and the buffer struct.
@@ -70,7 +71,6 @@ impl BufferedUart {
     pub fn reconfigure(&self, _config: Config) {
         todo!();
     }
-
 }
 
 impl Default for BufferedUart {

--- a/src/espressif/mod.rs
+++ b/src/espressif/mod.rs
@@ -1,3 +1,3 @@
+pub mod buffered_uart;
 pub mod net;
 pub mod rng;
-pub mod buffered_uart;

--- a/src/espressif/net.rs
+++ b/src/espressif/net.rs
@@ -12,9 +12,7 @@ use esp_hal::peripherals::WIFI;
 use esp_hal::rng::Rng;
 use esp_println::{dbg, println};
 
-use esp_wifi::wifi::{
-    AccessPointConfiguration, Configuration, WifiDevice, WifiController,
-};
+use esp_wifi::wifi::{AccessPointConfiguration, Configuration, WifiController, WifiDevice};
 use esp_wifi::wifi::{WifiEvent, WifiState};
 use esp_wifi::EspWifiController;
 
@@ -49,8 +47,7 @@ pub async fn if_up(
     rng: &mut Rng,
 ) -> Result<Stack<'static>, sunset::Error> {
     let wifi_init = &*mk_static!(EspWifiController<'static>, wifi_controller);
-    let (controller, interfaces) =
-        esp_wifi::wifi::new(wifi_init, wifi).unwrap();
+    let (controller, interfaces) = esp_wifi::wifi::new(wifi_init, wifi).unwrap();
 
     let gw_ip_addr_str = GW_IP_ADDR_ENV.unwrap_or("192.168.0.1");
     let gw_ip_addr = Ipv4Addr::from_str(gw_ip_addr_str).expect("failed to parse gateway ip");
@@ -92,9 +89,7 @@ pub async fn if_up(
     Ok(ap_stack)
 }
 
-pub async fn accept_requests(
-    stack: Stack<'static>,
-    uart: &BufferedUart) -> ! {
+pub async fn accept_requests(stack: Stack<'static>, uart: &BufferedUart) -> ! {
     let rx_buffer = mk_static!([u8; 1536], [0; 1536]);
     let tx_buffer = mk_static!([u8; 1536], [0; 1536]);
 
@@ -119,7 +114,7 @@ pub async fn accept_requests(
             Ok(_) => (),
             Err(e) => {
                 println!("SSH client fatal error: {}", e);
-            },
+            }
         };
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,9 +17,7 @@ async fn main(spawner: Spawner) -> ! {
     esp_println::logger::init_logger_from_env();
 
     // System init
-    let peripherals = esp_hal::init({
-        esp_hal::Config::default()
-    });
+    let peripherals = esp_hal::init(esp_hal::Config::default());
     let mut rng = Rng::new(peripherals.RNG);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,8 +50,13 @@ async fn main(spawner: Spawner) -> ! {
             let interrupt_spawner = interrupt_exeuctor.start(Priority::Priority10);
         }
     }
+    cfg_if::cfg_if! {
+        if #[cfg(not(feature = "esp32c2"))] {
     interrupt_spawner.spawn(uart_task(uart_buf, peripherals.UART1, peripherals.GPIO11.into(), peripherals.GPIO10.into())).unwrap();
-
+        } else {
+            interrupt_spawner.spawn(uart_task(uart_buf, peripherals.UART1, peripherals.GPIO9.into(), peripherals.GPIO10.into())).unwrap();
+        }
+    }
     accept_requests(tcp_stack, uart_buf).await;
 }
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -2,8 +2,8 @@ use embassy_futures::select::select;
 use embedded_io_async::{Read, Write};
 
 // Espressif specific crates
-use esp_println::println;
 use crate::espressif::buffered_uart::BufferedUart;
+use esp_println::println;
 
 /// Forwards an incoming SSH connection to/from the local UART, until
 /// the connection drops
@@ -11,17 +11,18 @@ pub(crate) async fn serial_bridge(
     chanr: impl Read<Error = sunset::Error>,
     chanw: impl Write<Error = sunset::Error>,
     uart: &BufferedUart,
-) -> Result<(), sunset::Error>
-{
+) -> Result<(), sunset::Error> {
     println!("Starting serial <--> SSH bridge");
 
-    select(uart_to_ssh(uart, chanw),
-           ssh_to_uart(chanr, uart)).await;
+    select(uart_to_ssh(uart, chanw), ssh_to_uart(chanr, uart)).await;
     println!("Stopping serial <--> SSH bridge");
     Ok(())
 }
 
-async fn uart_to_ssh(uart_buf: &BufferedUart, mut chanw: impl Write<Error = sunset::Error>) -> Result<(), sunset::Error> {
+async fn uart_to_ssh(
+    uart_buf: &BufferedUart,
+    mut chanw: impl Write<Error = sunset::Error>,
+) -> Result<(), sunset::Error> {
     let mut ssh_tx_buf = [0u8; 512];
     loop {
         let n = uart_buf.read(&mut ssh_tx_buf).await;
@@ -29,7 +30,10 @@ async fn uart_to_ssh(uart_buf: &BufferedUart, mut chanw: impl Write<Error = suns
     }
 }
 
-async fn ssh_to_uart(mut chanr: impl Read<Error = sunset::Error>, uart_buf: &BufferedUart) -> Result<(), sunset::Error> {
+async fn ssh_to_uart(
+    mut chanr: impl Read<Error = sunset::Error>,
+    uart_buf: &BufferedUart,
+) -> Result<(), sunset::Error> {
     let mut uart_tx_buf = [0u8; 64];
     loop {
         let n = chanr.read(&mut uart_tx_buf).await?;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -2,7 +2,6 @@ use core::option::Option::{self, None, Some};
 use core::result::Result;
 use core::writeln;
 
-
 use crate::espressif::buffered_uart::BufferedUart;
 use crate::keys;
 use crate::serial::serial_bridge;
@@ -13,7 +12,6 @@ use embassy_net::tcp::TcpSocket;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::mutex::Mutex;
-
 
 use heapless::String;
 use sunset::{error, ChanHandle, ServEvent, SignKey};


### PR DESCRIPTION
First, sorry as this PR ended up doing many different things as:
- Added run aliases
- Cargo fmt/clippy fixes
- Improve CI to build all targets
  - Currently only checks fmt/lints for C6 but it migth be worth to check it for all targets if the code has too many conditionals snippets 
-  Updated the GPIOs used for C2